### PR TITLE
Other unzip

### DIFF
--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -4,7 +4,7 @@ var path = require('path');
 var _ = require('lodash');
 var request = require('request');
 var async = require('async');
-var unzip = require('unzip');
+var extractZip = require('extract-zip');
 
 var API_URL = 'http://ffbinaries.com/api/v1';
 // var API_URL = 'http://localhost:3000/api/v1';
@@ -182,35 +182,7 @@ function _downloadUrls (urls, opts, callback) {
     var oldpath = LOCAL_CACHE_DIR + '/' + filename;
 
     console.log('Extracting ' + oldpath + ' to ' + destinationDir);
-    var readStream = fse.createReadStream(oldpath);
-    var extractor = unzip.Extract({path: destinationDir});
-
-    extractor.on('close', function () {
-      console.log('Extracted "' + filename + '" to destination');
-
-      // apply chmod +x
-      try {
-        var extractedFilename;
-        if (os.type() === 'Darwin' || os.type() === 'Linux') {
-          if (filename.startsWith('ffmpeg')) extractedFilename = 'ffmpeg';
-          if (filename.startsWith('ffplay')) extractedFilename = 'ffplay';
-          if (filename.startsWith('ffprobe')) extractedFilename = 'ffprobe';
-          if (filename.startsWith('ffserver')) extractedFilename = 'ffserver';
-        }
-
-        if (extractedFilename) {
-          fse.chmodSync(destinationDir + '/' + extractedFilename, 0744);
-          console.log('Applied 0744 chmod to "' + extractedFilename + '"');
-        }
-      } catch (e) {
-        // ignore permission errors for now
-        // console.error(e);
-      }
-
-      if (typeof cb === 'function') cb();
-    });
-
-    readStream.pipe(extractor);
+    extractZip(oldpath, { dir: destinationDir, defaultFileMode: 0744 }, cb);
   }
 
 

--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -182,7 +182,7 @@ function _downloadUrls (urls, opts, callback) {
     var oldpath = LOCAL_CACHE_DIR + '/' + filename;
 
     console.log('Extracting ' + oldpath + ' to ' + destinationDir);
-    extractZip(oldpath, { dir: destinationDir, defaultFileMode: 0744 }, cb);
+    extractZip(oldpath, { dir: destinationDir, defaultFileMode: parseInt('744', 8) }, cb);
   }
 
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "extract-zip": "^1.6.0",
     "fs-extra": "^1.0.0",
     "lodash": "^4.16.6",
-    "request": "^2.78.0",
+    "request": "^2.78.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,19 @@
   },
   "scripts": {},
   "keywords": [
-    "ffmpeg", "ffserver", "ffplay", "ffprobe",
-    "bin", "binaries", "static", "cli", "audio", "video",
-    "windows", "linux", "mac"
+    "ffmpeg",
+    "ffserver",
+    "ffplay",
+    "ffprobe",
+    "bin",
+    "binaries",
+    "static",
+    "cli",
+    "audio",
+    "video",
+    "windows",
+    "linux",
+    "mac"
   ],
   "repository": {
     "type": "git",
@@ -25,9 +35,9 @@
   "dependencies": {
     "async": "^2.1.2",
     "clarg": "0.0.3",
+    "extract-zip": "^1.6.0",
     "fs-extra": "^1.0.0",
     "lodash": "^4.16.6",
     "request": "^2.78.0",
-    "unzip": "^0.1.11"
   }
 }


### PR DESCRIPTION
updated to use `extract-zip`, as `unzip` is no longer maintained and wouldn't agree with webpack, among other things.

