### PR TITLE
Update README.md 'Methods' 'output' parameter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,12 @@ There are also `ffbinaries help`, `ffbinaries versions` and `ffbinaries clearcac
 
 * `downloadFiles(platform, output, callback)` downloads and extracts the requested binaries.
 
+   * The `output` parameter is an object that can contain following optional parameters=
+      * `destination`: holds the path where ffbinaries will write the downloaded binaries to. If not provided it will default to `.`.
+      * `components`: an array of string values that describes which [components](#included-components) to download. If not provided it will default to all components available for the platform.
+      * `version`: the version of the ffmpeg binaries/components
+      * `quiet`: logs no output
+
 * `getVersionData(version, callback)` fetches the full data set without downloading any binaries.
 
 * `listVersions(callback)` returns the list of available versions from the API


### PR DESCRIPTION
Updated README.md 'Methods' with 'output' parameter information. As this originally got me confused (see issue: https://github.com/vot/ffbinaries-node/issues/4). Hope this is of any help and correct, if not, please edit any errors.