### PR TITLE
Azure WebApp Compliance

### DIFF
--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -9,7 +9,7 @@ var extractZip = require('extract-zip');
 
 var API_URL = 'https://ffbinaries.com/api/v1';
 
-var LOCAL_CACHE_DIR = os.homedir() + '/.ffbinaries-cache';
+var LOCAL_CACHE_DIR = os.tmpdir() + '/.ffbinaries-cache';
 var RUNTIME_CACHE = {};
 var errorMsgs = {
   connectionIssues: 'Couldn\'t connect to ffbinaries.com API. Check your Internet connection.',
@@ -19,7 +19,7 @@ var errorMsgs = {
   incorrectVersionParam: '"version" parameter must be a string.'
 };
 
-function _ensureDirSync (dir) {
+function _ensureDirSync(dir) {
   try {
     fse.accessSync(dir);
   } catch (e) {
@@ -32,7 +32,7 @@ _ensureDirSync(LOCAL_CACHE_DIR);
 /**
  * Resolves the platform key based on input string
  */
-function resolvePlatform (input) {
+function resolvePlatform(input) {
   var rtn = null;
 
   switch (input) {
@@ -40,43 +40,43 @@ function resolvePlatform (input) {
     case 'osx':
     case 'mac-64':
     case 'osx-64':
-        rtn = 'osx-64';
-        break;
+      rtn = 'osx-64';
+      break;
 
     case 'linux':
     case 'linux-32':
-        rtn = 'linux-32';
-        break;
+      rtn = 'linux-32';
+      break;
 
     case 'linux-64':
-        rtn = 'linux-64';
-        break;
+      rtn = 'linux-64';
+      break;
 
     case 'linux-arm':
     case 'linux-armel':
-        rtn = 'linux-armel';
-        break;
+      rtn = 'linux-armel';
+      break;
 
     case 'linux-armhf':
-        rtn = 'linux-armhf';
-        break;
+      rtn = 'linux-armhf';
+      break;
 
     case 'win':
     case 'win-32':
     case 'windows':
     case 'windows-32':
-        rtn = 'windows-32';
-        break;
+      rtn = 'windows-32';
+      break;
 
     case 'win-64':
     case 'windows-64':
-        rtn = 'windows-64';
-        break;
+      rtn = 'windows-64';
+      break;
 
     default:
-        rtn = null;
-    }
-    return rtn;
+      rtn = null;
+  }
+  return rtn;
 }
 /**
  * Detects the platform of the machine the script is executed on.
@@ -84,7 +84,7 @@ function resolvePlatform (input) {
  *
  * @param {object} osinfo Contains "type" and "arch" properties
  */
-function detectPlatform (osinfo) {
+function detectPlatform(osinfo) {
   var inputIsValid = typeof osinfo === 'object' && typeof osinfo.type === 'string' && typeof osinfo.arch === 'string';
   var type = (inputIsValid ? osinfo.type : os.type()).toLowerCase();
   var arch = (inputIsValid ? osinfo.arch : os.arch()).toLowerCase();
@@ -112,7 +112,7 @@ function detectPlatform (osinfo) {
  * @param {string} component "ffmpeg", "ffplay", "ffprobe" or "ffserver"
  * @param {platform} platform "ffmpeg", "ffplay", "ffprobe" or "ffserver"
  */
-function getBinaryFilename (component, platform) {
+function getBinaryFilename(component, platform) {
   var platformCode = resolvePlatform(platform);
   if (platformCode === 'windows-32' || platformCode === 'windows-64') {
     return component + '.exe';
@@ -128,7 +128,7 @@ function listVersions(callback) {
   if (RUNTIME_CACHE['versions']) {
     return callback(null, RUNTIME_CACHE['versionsAll']);
   }
-  request({url: API_URL}, function (err, response, body) {
+  request({ url: API_URL }, function (err, response, body) {
     if (err) {
       return callback(errorMsgs.connectionIssues);
     }
@@ -147,7 +147,7 @@ function listVersions(callback) {
 /**
  * Gets full data set from ffbinaries.com
  */
-function getVersionData (version, callback) {
+function getVersionData(version, callback) {
   if (RUNTIME_CACHE[version]) {
     return callback(null, RUNTIME_CACHE[version]);
   }
@@ -158,7 +158,7 @@ function getVersionData (version, callback) {
 
   var url = version ? '/version/' + version : '/latest';
 
-  request({url: API_URL + url}, function (err, response, body) {
+  request({ url: API_URL + url }, function (err, response, body) {
     if (err) {
       return callback(errorMsgs.connectionIssues);
     }
@@ -181,7 +181,7 @@ function getVersionData (version, callback) {
 /**
  * Download file(s) and save them in the specified directory
  */
-function _downloadUrls (components, urls, opts, callback) {
+function _downloadUrls(components, urls, opts, callback) {
   if (components && !Array.isArray(components)) {
     components = [components];
   }
@@ -189,7 +189,7 @@ function _downloadUrls (components, urls, opts, callback) {
   // returns an array of objects like this: {component: 'ffmpeg', url: 'https://...'}
   if (typeof urls === 'object') {
     var remappedUrls = _.map(urls, function (v, k) {
-      return (!components || components && !Array.isArray(components) || components && Array.isArray(components) && components.indexOf(k) !== -1) ? {component: k, url: v} : null;
+      return (!components || components && !Array.isArray(components) || components && Array.isArray(components) && components.indexOf(k) !== -1) ? { component: k, url: v } : null;
     });
     remappedUrls = _.compact(remappedUrls);
   }
@@ -197,7 +197,7 @@ function _downloadUrls (components, urls, opts, callback) {
   var destinationDir = opts.destination;
   var cacheDir = LOCAL_CACHE_DIR;
 
-  function _extractZipToDestination (zipFilename, cb) {
+  function _extractZipToDestination(zipFilename, cb) {
     var oldpath = LOCAL_CACHE_DIR + '/' + zipFilename;
     extractZip(oldpath, { dir: destinationDir, defaultFileMode: parseInt('744', 8) }, cb);
   }
@@ -227,7 +227,7 @@ function _downloadUrls (components, urls, opts, callback) {
         if (totalFilesize && runningTotal == totalFilesize) {
           return clearInterval(interval);
         }
-        tickData.progress = totalFilesize > -1 ? runningTotal/totalFilesize : 0;
+        tickData.progress = totalFilesize > -1 ? runningTotal / totalFilesize : 0;
 
         opts.tickerFn(tickData);
       }, tickerInterval);
@@ -268,11 +268,11 @@ function _downloadUrls (components, urls, opts, callback) {
         var cacheFileTempName = LOCAL_CACHE_DIR + '/' + zipFilename + '.part';
         var cacheFileFinalName = LOCAL_CACHE_DIR + '/' + zipFilename;
 
-        request({url: url}, function (err, response, body) {
+        request({ url: url }, function (err, response, body) {
           results.push({
             filename: binFilename,
             path: destinationDir,
-            size: Math.floor(totalFilesize/1024/1024*1000)/1000 + 'MB',
+            size: Math.floor(totalFilesize / 1024 / 1024 * 1000) / 1000 + 'MB',
             status: 'File extracted to destination (downloaded from "' + url + '")',
             code: 'DONE_CLEAN'
           });
@@ -280,13 +280,13 @@ function _downloadUrls (components, urls, opts, callback) {
           fse.renameSync(cacheFileTempName, cacheFileFinalName);
           _extractZipToDestination(zipFilename, cb);
         })
-        .on('response', function(response) {
-          totalFilesize = response.headers['content-length'];
-        })
-        .on('data', function (data) {
-          runningTotal += data.length;
-        })
-        .pipe(fse.createWriteStream(cacheFileTempName));
+          .on('response', function (response) {
+            totalFilesize = response.headers['content-length'];
+          })
+          .on('data', function (data) {
+            runningTotal += data.length;
+          })
+          .pipe(fse.createWriteStream(cacheFileTempName));
       }
     }
 
@@ -305,7 +305,7 @@ function _downloadUrls (components, urls, opts, callback) {
  * @param {object}   opts
  * @param {function} callback
  */
-function downloadBinaries (components, opts, callback) {
+function downloadBinaries(components, opts, callback) {
   // only callback provided: assign blank components and opts
   if (!callback && !opts && typeof components === 'function') {
     callback = components;
@@ -408,7 +408,7 @@ function locateBinariesSync(components, opts) {
       try {
         childProcess.execSync('chmod +x ' + result.path);
         result.isExecutable = true;
-      } catch (err) {}
+      } catch (err) { }
     }
 
     // check version
@@ -426,7 +426,7 @@ function locateBinariesSync(components, opts) {
   return rtn;
 }
 
-function clearCache () {
+function clearCache() {
   fse.emptyDirSync(LOCAL_CACHE_DIR);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffbinaries",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Download binaries for ffmpeg, ffprobe, ffserver and ffplay (cross-platform)",
   "main": "index.js",
   "bin": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,12 +4,12 @@ var os = require('os');
 var fs = require('fs-extra');
 var glob = require('glob');
 
-var LOCAL_CACHE_DIR = os.homedir() + '/.ffbinaries-cache';
+var LOCAL_CACHE_DIR = os.tmpdir() + '/.ffbinaries-cache';
 
 
-describe('ffbinaries CLI', function() {
-  describe('commands', function() {
-    it('help works', function(done) {
+describe('ffbinaries CLI', function () {
+  describe('commands', function () {
+    it('help works', function (done) {
       var ls = spawn('node', ['./cli.js', 'help']);
       var stdout = [];
       var stderr = [];
@@ -31,7 +31,7 @@ describe('ffbinaries CLI', function() {
       });
     });
 
-    it('clearcache works', function(done) {
+    it('clearcache works', function (done) {
       var ls = spawn('node', ['./cli.js', 'clearcache']);
       var stdout = [];
       var stderr = [];

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -6,65 +6,65 @@ var glob = require('glob');
 var childProcess = require('child_process');
 var _ = require('lodash');
 
-var LOCAL_CACHE_DIR = os.homedir() + '/.ffbinaries-cache';
+var LOCAL_CACHE_DIR = os.tmpdir() + '/.ffbinaries-cache';
 
-describe('ffbinaries library', function() {
-  describe('detectPlatform', function() {
-    it('should autodetect platform successfully', function() {
+describe('ffbinaries library', function () {
+  describe('detectPlatform', function () {
+    it('should autodetect platform successfully', function () {
       var platform = ffbinaries.detectPlatform();
       expect(typeof platform).to.equal('string');
     });
 
-    it('should return null when no matches found', function() {
-      var osinfo = {type: 'potato', arch: 'golden'};
+    it('should return null when no matches found', function () {
+      var osinfo = { type: 'potato', arch: 'golden' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal(null);
     });
 
-    it('should detect Mac OS X (64 bit)', function() {
-      var osinfo = {type: 'darwin', arch: 'x64'};
+    it('should detect Mac OS X (64 bit)', function () {
+      var osinfo = { type: 'darwin', arch: 'x64' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('osx-64');
     });
 
-    it('should detect Windows (32 bit)', function() {
-      var osinfo = {type: 'windows_nt', arch: 'anything'};
+    it('should detect Windows (32 bit)', function () {
+      var osinfo = { type: 'windows_nt', arch: 'anything' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('windows-32');
     });
 
-    it('should detect Windows (64 bit)', function() {
-      var osinfo = {type: 'windows_nt', arch: 'x64'};
+    it('should detect Windows (64 bit)', function () {
+      var osinfo = { type: 'windows_nt', arch: 'x64' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('windows-64');
     });
 
-    it('should detect Linux (32 bit)', function() {
-      var osinfo = {type: 'linux', arch: 'anything'};
+    it('should detect Linux (32 bit)', function () {
+      var osinfo = { type: 'linux', arch: 'anything' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('linux-32');
     });
 
-    it('should detect Linux (64 bit)', function() {
-      var osinfo = {type: 'linux', arch: 'x64'};
+    it('should detect Linux (64 bit)', function () {
+      var osinfo = { type: 'linux', arch: 'x64' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('linux-64');
     });
 
-    it('should detect Linux (ARM)', function() {
-      var osinfo = {type: 'linux', arch: 'arm'};
+    it('should detect Linux (ARM)', function () {
+      var osinfo = { type: 'linux', arch: 'arm' };
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('linux-armel');
     });
   });
 
-  describe('resolvePlatform', function() {
-    it('empty platform should return null', function() {
+  describe('resolvePlatform', function () {
+    it('empty platform should return null', function () {
       var resolved = ffbinaries.resolvePlatform();
       expect(resolved).to.deep.equal(null);
     });
 
-    it('should resolve all aliases', function() {
+    it('should resolve all aliases', function () {
       var map = {
         'mac': 'osx-64',
         'osx': 'osx-64',
@@ -92,38 +92,38 @@ describe('ffbinaries library', function() {
     });
   });
 
-  describe('getBinaryFilename', function() {
-    it('should add ".exe" in windows-32', function() {
+  describe('getBinaryFilename', function () {
+    it('should add ".exe" in windows-32', function () {
       var result = ffbinaries.getBinaryFilename('ffmpeg', 'windows-32');
       expect(result).to.equal('ffmpeg.exe');
     });
 
-    it('should add ".exe" in windows-64', function() {
+    it('should add ".exe" in windows-64', function () {
       var result = ffbinaries.getBinaryFilename('ffserver', 'windows-64');
       expect(result).to.equal('ffserver.exe');
     });
 
-    it('should not add extension in linux', function() {
+    it('should not add extension in linux', function () {
       var result = ffbinaries.getBinaryFilename('ffprobe', 'linux');
       expect(result).to.equal('ffprobe');
     });
 
-    it('should not add extension in mac', function() {
+    it('should not add extension in mac', function () {
       var result = ffbinaries.getBinaryFilename('ffplay', 'mac');
       expect(result).to.equal('ffplay');
     });
   });
 
-  describe('listPlatforms', function() {
-    it('should return 7 platforms in an array', function() {
+  describe('listPlatforms', function () {
+    it('should return 7 platforms in an array', function () {
       var platforms = ffbinaries.listPlatforms();
       expect(Array.isArray(platforms)).to.equal(true);
       expect(platforms.length).to.equal(7);
     });
   });
 
-  describe('listVersions', function() {
-    it('should return at least "latest" and "3.2"', function(done) {
+  describe('listVersions', function () {
+    it('should return at least "latest" and "3.2"', function (done) {
       ffbinaries.listVersions(function (err, data) {
         expect(data.indexOf('latest') === -1).to.equal(false);
         expect(data.indexOf('3.2') === -1).to.equal(false);
@@ -132,8 +132,8 @@ describe('ffbinaries library', function() {
     });
   });
 
-  describe('getVersionData', function() {
-    it('should return a correct response for "latest"', function(done) {
+  describe('getVersionData', function () {
+    it('should return a correct response for "latest"', function (done) {
       ffbinaries.getVersionData('latest', function (err, data) {
         expect(data.version).to.exist;
         expect(data.permalink).to.exist;
@@ -143,7 +143,7 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should throw an error for non-existent versions', function(done) {
+    it('should throw an error for non-existent versions', function (done) {
       ffbinaries.getVersionData('potato', function (err, data) {
         expect(err).to.be.ok;
 
@@ -151,7 +151,7 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should throw an error for non-string values', function(done) {
+    it('should throw an error for non-string values', function (done) {
       ffbinaries.getVersionData([1, null, {}], function (err, data) {
         expect(err).to.be.ok;
 
@@ -160,8 +160,8 @@ describe('ffbinaries library', function() {
     });
   });
 
-  describe('clearCache', function() {
-    it('should remove contents of ~/.ffbinaries-cache directory', function() {
+  describe('clearCache', function () {
+    it('should remove contents of ~/.ffbinaries-cache directory', function () {
       ffbinaries.clearCache();
       var dirExists = fs.existsSync(LOCAL_CACHE_DIR);
       var dirContents = glob.sync(LOCAL_CACHE_DIR + '/*.zip');
@@ -170,14 +170,14 @@ describe('ffbinaries library', function() {
     });
   });
 
-  describe('downloadBinaries (each test will take a while or time out after 2 minutes)', function() {
-    it('should download a single file (ffmpeg@3.2, win-64) with options provided', function(done) {
+  describe('downloadBinaries (each test will take a while or time out after 2 minutes)', function () {
+    it('should download a single file (ffmpeg@3.2, win-64) with options provided', function (done) {
       this.timeout(120000);
       var dest = __dirname + '/binaries';
-      var tickerFn = function () {};
-      var tickerInterval = function () {};
+      var tickerFn = function () { };
+      var tickerInterval = function () { };
 
-      ffbinaries.downloadBinaries('ffmpeg', {version: '3.2', platform: 'win-64', quiet: true, destination: dest, tickerFn: tickerFn, tickerInterval: tickerInterval}, function (err, data) {
+      ffbinaries.downloadBinaries('ffmpeg', { version: '3.2', platform: 'win-64', quiet: true, destination: dest, tickerFn: tickerFn, tickerInterval: tickerInterval }, function (err, data) {
         expect(err).to.equal(null);
         expect(data.length).to.equal(1);
         expect(data[0].filename).to.exist;
@@ -186,7 +186,7 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should download multiple components without options provided', function(done) {
+    it('should download multiple components without options provided', function (done) {
       this.timeout(120000);
       ffbinaries.downloadBinaries(['ffmpeg', 'ffprobe'], function (err, data) {
         expect(err).to.equal(null);
@@ -198,7 +198,7 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should download all components if none are specified', function(done) {
+    it('should download all components if none are specified', function (done) {
       this.timeout(120000);
       ffbinaries.downloadBinaries(function (err, data) {
         expect(err).to.equal(null);
@@ -211,11 +211,11 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should download all components if none are specified and options are provided as first argument', function(done) {
+    it('should download all components if none are specified and options are provided as first argument', function (done) {
       this.timeout(120000);
       var dest = __dirname + '/binaries';
 
-      ffbinaries.downloadBinaries({destination: dest}, function (err, data) {
+      ffbinaries.downloadBinaries({ destination: dest }, function (err, data) {
         expect(err).to.equal(null);
         expect(data.length).to.be.at.least(3);
         expect(data[0].filename).to.exist;
@@ -226,7 +226,7 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should use cache for repeat requests', function(done) {
+    it('should use cache for repeat requests', function (done) {
       this.timeout(3000);
       var dest = __dirname + '/binaries';
       // remove the binaries from earlier tests to fall back to cache
@@ -234,7 +234,7 @@ describe('ffbinaries library', function() {
       // so it's safe to just remove it
       fs.removeSync(dest);
 
-      ffbinaries.downloadBinaries('ffmpeg', {quiet: true, destination: dest}, function (err, data) {
+      ffbinaries.downloadBinaries('ffmpeg', { quiet: true, destination: dest }, function (err, data) {
         expect(err).to.equal(null);
         expect(data.length).to.equal(1);
         expect(data[0].filename).to.exist;
@@ -244,11 +244,11 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should indicate an existing file and not do anything', function(done) {
+    it('should indicate an existing file and not do anything', function (done) {
       this.timeout(3000);
       var dest = __dirname + '/binaries';
 
-      ffbinaries.downloadBinaries('ffmpeg', {quiet: true, destination: dest}, function (err, data) {
+      ffbinaries.downloadBinaries('ffmpeg', { quiet: true, destination: dest }, function (err, data) {
         expect(err).to.equal(null);
         expect(data.length).to.equal(1);
         expect(data[0].filename).to.exist;
@@ -259,9 +259,9 @@ describe('ffbinaries library', function() {
       });
     });
 
-    it('should ignore existing binaries with force option provided', function(done) {
+    it('should ignore existing binaries with force option provided', function (done) {
       this.timeout(5000);
-      ffbinaries.downloadBinaries('ffmpeg', {force: true}, function (err, data) {
+      ffbinaries.downloadBinaries('ffmpeg', { force: true }, function (err, data) {
         expect(err).to.equal(null);
         expect(data.length).to.equal(1);
         expect(data[0].filename).to.exist;
@@ -274,21 +274,21 @@ describe('ffbinaries library', function() {
   });
 
 
-  describe('locateBinariesSync', function() {
-    it('should locate ffmpeg binary in the current dir', function() {
-      var result = ffbinaries.locateBinariesSync('ffmpeg', {paths: process.cwd()});
+  describe('locateBinariesSync', function () {
+    it('should locate ffmpeg binary in the current dir', function () {
+      var result = ffbinaries.locateBinariesSync('ffmpeg', { paths: process.cwd() });
       expect(result.ffmpeg).to.exist;
       expect(result.ffmpeg.found).to.equal(true);
     });
 
-    it('should return version as "error" for a non-executable file', function() {
+    it('should return version as "error" for a non-executable file', function () {
       if (ffbinaries.detectPlatform().indexOf('windows-') === 0) {
         return;
       }
 
       childProcess.execSync('chmod -x ' + process.cwd() + '/ffmpeg');
 
-      var result = ffbinaries.locateBinariesSync('ffmpeg', {paths: process.cwd()});
+      var result = ffbinaries.locateBinariesSync('ffmpeg', { paths: process.cwd() });
       expect(result.ffmpeg).to.exist;
       expect(result.ffmpeg.found).to.equal(true);
       expect(result.ffmpeg.isExecutable).to.equal(false);
@@ -296,14 +296,14 @@ describe('ffbinaries library', function() {
       expect(result.ffmpeg.version).to.equal('error');
     });
 
-    it('should set chmod +x when "ensureExecutable" option is provided', function() {
+    it('should set chmod +x when "ensureExecutable" option is provided', function () {
       if (ffbinaries.detectPlatform().indexOf('windows-') === 0) {
         return;
       }
 
       childProcess.execSync('chmod -x ' + process.cwd() + '/ffmpeg');
 
-      var result = ffbinaries.locateBinariesSync('ffmpeg', {paths: [process.cwd()], ensureExecutable: true});
+      var result = ffbinaries.locateBinariesSync('ffmpeg', { paths: [process.cwd()], ensureExecutable: true });
       expect(result.ffmpeg).to.exist;
       expect(result.ffmpeg.found).to.equal(true);
       expect(result.ffmpeg.isExecutable).to.equal(true);
@@ -311,11 +311,11 @@ describe('ffbinaries library', function() {
       expect(result.ffmpeg.version).to.not.equal('error');
     });
 
-    it('should return missing binaries correctly', function() {
+    it('should return missing binaries correctly', function () {
       fs.removeSync(process.cwd() + '/ffplay');
       fs.removeSync(process.cwd() + '/ffplay.exe');
 
-      var result = ffbinaries.locateBinariesSync(['ffmpeg', 'ffplay'], {paths: process.cwd()});
+      var result = ffbinaries.locateBinariesSync(['ffmpeg', 'ffplay'], { paths: process.cwd() });
       expect(result.ffmpeg).to.exist;
 
       expect(result.ffplay).to.exist;


### PR DESCRIPTION
os.homeDir() is not accessible when deployed on Azure WebApp platform, so changed for os.tmpdir().